### PR TITLE
Fix GitHub spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
     <img src="http://maxcdn.fooyoh.com/files/attach/images/591/736/904/004/haters_gonna_hate.gif"/>
   </td>
   <td>
-    <p/>Provides some extended utilities for the Github API for operating against <strong>multiple Github issue trackers at once</strong>.
+    <p/>Provides some extended utilities for the GitHub API for operating against <strong>multiple GitHub issue trackers at once</strong>.
   </td>
 </tr>
 </table>
 
-If you're like me, this library might save you an hour a week. I'm a "scrum master", which sounds silly but is actually a real thing. <a href="https://github.com/numenta/">We have a lot of repos on Github</a>. Most of them have issue trackers. So it takes a long time to update all of them for common recurring tasks like sprint changes. This library takes your Github credentials [2] and gives you easy ways to set up tasks that execute against multiple Github Issue Trackers at once, so you can:
+If you're like me, this library might save you an hour a week. I'm a "scrum master", which sounds silly but is actually a real thing. <a href="https://github.com/numenta/">We have a lot of repos on GitHub</a>. Most of them have issue trackers. So it takes a long time to update all of them for common recurring tasks like sprint changes. This library takes your GitHub credentials [2] and gives you easy ways to set up tasks that execute against multiple GitHub Issue Trackers at once, so you can:
 
 Run the following actions across multiple repos:
 
@@ -28,7 +28,7 @@ Run the following actions across multiple repos:
 
 ## Example Usage
 
-Sprinter is used as the backend to report on issues across all the repositories in the [Numenta Github Organization](https://github.com/numenta/) on our [status board](http://status.numenta.org/issues.html).
+Sprinter is used as the backend to report on issues across all the repositories in the [Numenta GitHub Organization](https://github.com/numenta/) on our [status board](http://status.numenta.org/issues.html).
 
 ## Installation
 
@@ -51,7 +51,7 @@ Displays usage information.
     Sprinter CLI Tool: Utilities for operating on issue trackers of several repositories at once.
     
     REQUIREMENTS
-    Environment variables with the Github username and password for API calls:
+    Environment variables with the GitHub username and password for API calls:
     	GH_USERNAME=<username>
     	GH_PASSWORD=<password>
     

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -38,7 +38,7 @@ function printHelp() {
     var help = "\nSprinter CLI Tool".bold.magenta + ": Utilities for operating on issue trackers "
         + "of several repositories at once.\n\n"
         + "REQUIREMENTS\n".underline
-        + "Environment variables with the Github username and password for API calls:\n"
+        + "Environment variables with the GitHub username and password for API calls:\n"
         + "\tGH_USERNAME=<username>\n".grey
         + "\tGH_PASSWORD=<password>\n".grey
         + "\nUSAGE\n".underline
@@ -103,11 +103,11 @@ function processArgs(args) {
     }
 }
 
-function exitIfMissingGithubCreds() {
+function exitIfMissingGitHubCreds() {
     githubUsername = process.env['GH_USERNAME'];
     githubPassword = process.env['GH_PASSWORD'];
     if (! githubUsername || ! githubPassword) {
-        console.error(('You must set your Github credentials into the '
+        console.error(('You must set your GitHub credentials into the '
                     + 'environment for this script to run.\n'
                     + '    export GH_USERNAME=<username>\n'
                     + '    export GH_USERNAME=<username>').red);
@@ -192,7 +192,7 @@ function closeMilestonesCli(sprinter, command, commandArgs, kwargs) {
 }
 
 processArgs(argv);
-exitIfMissingGithubCreds();
+exitIfMissingGitHubCreds();
 
 sprinter = new Sprinter(
     githubUsername,

--- a/sprinter.js
+++ b/sprinter.js
@@ -23,11 +23,11 @@ function sortIssues(issues) {
 }
 
 /**
- * Wrapper class around the Github API client, providing some authentication
+ * Wrapper class around the GitHub API client, providing some authentication
  * convenience and additional utility functions for executing operations across
  * the issue trackers of several repositories at once.
- * @param username {string} Github username credential for authentication.
- * @param password {string} Github password credential for authentication.
+ * @param username {string} GitHub username credential for authentication.
+ * @param password {string} GitHub password credential for authentication.
  * @param repoSlugs {string[]} List of repository slug strings to operate upon.
  */
 function Sprinter(username, password, repoSlugs) {

--- a/test/sprinter-test.js
+++ b/test/sprinter-test.js
@@ -10,18 +10,18 @@ describe('sprinter', function() {
 
     describe('when constructed', function() {
         var authenticated = false;
-        var mockGithubInstance = {
+        var mockGitHubInstance = {
             authenticate: function(params) {
-                assert.equal('basic', params.type, 'Missing Github auth type during authentication.');
-                assert.equal('my-username', params.username, 'Missing Github username during authentication.');
-                assert.equal('my-password', params.password, 'Missing Github password during authentication.');
+                assert.equal('basic', params.type, 'Missing GitHub auth type during authentication.');
+                assert.equal('my-username', params.username, 'Missing GitHub username during authentication.');
+                assert.equal('my-password', params.password, 'Missing GitHub password during authentication.');
                 authenticated = true;
             }
         };
 
         var Sprinter = proxyquire('../sprinter', {
             'github': function () {
-                return mockGithubInstance;
+                return mockGitHubInstance;
             }
         });
 
@@ -51,7 +51,7 @@ describe('sprinter', function() {
 
         describe('with required configuration', function() {
 
-            it('authenticates through Github', function() {
+            it('authenticates through GitHub', function() {
                 new Sprinter('my-username', 'my-password', ['repo1','repo2']);
                 assert.ok(authenticated, 'Sprinter did not authenticate upon construction.');
             });
@@ -61,12 +61,12 @@ describe('sprinter', function() {
     });
 
     describe('when fetching issues', function() {
-        var mockGithubInstance = {
+        var mockGitHubInstance = {
             authenticate: function() {},
             issues: {
                 repoIssues: function(params, callback) {
-                    expect(params).to.be.instanceOf(Object, 'Github client given no parameters.');
-                    expect(params).to.have.keys(['user', 'repo', 'state'], 'Github params are missing data.');
+                    expect(params).to.be.instanceOf(Object, 'GitHub client given no parameters.');
+                    expect(params).to.have.keys(['user', 'repo', 'state'], 'GitHub params are missing data.');
                     assert.includeMembers(['numenta', 'rhyolight'], [params.user], 'Repo user should be either numenta or rhyolight.');
                     assert.includeMembers(['nupic', 'sprinter.js'], [params.repo], 'Repo name should be either nupic or sprinter.js.');
                     expect(params.state).to.equal('open', 'Default state filter was not "open".');
@@ -83,7 +83,7 @@ describe('sprinter', function() {
 
         var Sprinter = proxyquire('../sprinter', {
             'github': function () {
-                return mockGithubInstance;
+                return mockGitHubInstance;
             }
         });
 
@@ -100,12 +100,12 @@ describe('sprinter', function() {
     });
 
     describe('when creating milestones', function() {
-        var mockGithubInstance = {
+        var mockGitHubInstance = {
             authenticate: function() {},
                 issues: {
                     createMilestone: function(params, callback) {
-                        expect(params).to.be.instanceOf(Object, 'Github client given no parameters.');
-                        expect(params).to.have.keys(['user', 'repo', 'title', 'due_on'], 'Github params are missing data.');
+                        expect(params).to.be.instanceOf(Object, 'GitHub client given no parameters.');
+                        expect(params).to.have.keys(['user', 'repo', 'title', 'due_on'], 'GitHub params are missing data.');
                         assert.includeMembers(['numenta', 'rhyolight'], [params.user], 'Repo user should be either numenta or rhyolight.');
                         expect(params.repo).to.equal('experiments');
                         expect(params.title).to.equal('Test Milestone');
@@ -123,7 +123,7 @@ describe('sprinter', function() {
 
         var Sprinter = proxyquire('../sprinter', {
             'github': function () {
-                return mockGithubInstance;
+                return mockGitHubInstance;
             }
         });
 


### PR DESCRIPTION
Just a minor cosmetic fix, changing Git{hub => Hub}.

Also please update it here:
![image](https://cloud.githubusercontent.com/assets/743291/3486081/56a1f732-041c-11e4-9903-ad83d4157e89.png)

Thanks for this useful script! :+1:
